### PR TITLE
[ENH] Add N-dimensional ordered subspace graph stitching (quite a big deal)

### DIFF
--- a/.github/workflows/testingOnPush_Apple.yaml
+++ b/.github/workflows/testingOnPush_Apple.yaml
@@ -26,6 +26,8 @@ jobs:
         run: nim c -r -d:release tests/graph.nim
       - name: Run CLI tests
         run: nim c -r -d:release tests/cli.nim
+      - name: Run stitching tests
+        run: nim c -r -d:release tests/stitching.nim 
   test-M1:
     runs-on: macos-14
     steps:
@@ -43,3 +45,5 @@ jobs:
         run: nim c -r -d:release tests/graph.nim
       - name: Run CLI tests
         run: nim c -r -d:release tests/cli.nim
+      - name: Run stitching tests
+        run: nim c -r -d:release tests/stitching.nim

--- a/.github/workflows/testingOnPush_Linux.yaml
+++ b/.github/workflows/testingOnPush_Linux.yaml
@@ -28,3 +28,5 @@ jobs:
         run: nim c -r -d:release tests/graph.nim
       - name: Run CLI tests
         run: nim c -r -d:release tests/cli.nim
+      - name: Run stitching tests
+        run: nim c -r -d:release tests/stitching.nim

--- a/.github/workflows/testingOnPush_Windows.yaml
+++ b/.github/workflows/testingOnPush_Windows.yaml
@@ -35,3 +35,5 @@ jobs:
         run: nim c -r -d:release tests/graph.nim
       - name: Run CLI tests
         run: nim c -r -d:release tests/cli.nim
+      - name: Run stitching tests
+        run: nim c -r -d:release tests/stitching.nim

--- a/docs/docs.nim
+++ b/docs/docs.nim
@@ -2,7 +2,7 @@
 ## 
 ## Such spaces are considered when an entity can be split into a set of distinct components (a composition), and they play a critical role in many disciplines of science, engineering, and mathematics. For instance, in materials science, chemical composition refers to the way a material (or, more generally, matter) is split into distinct components, such as chemical elements, based on considerations such as fraction of atoms, occupied volume, or contributed mass. And in economics, portfolio composition may refer to how finite capital is split across vehicles, such as cash, equity instruments, real estate, and commodities, based on their monetary value.
 ## 
-## **Navigation:** [nimplex](nimplex.html) (core library) | [docs/changelog](docs/changelog.html) | [utils/plotting](utils/plotting.html)
+## **Navigation:** [nimplex](nimplex.html) (core library) | [docs/changelog](docs/changelog.html) | [utils/plotting](utils/plotting.html) | [utils/stitching](utils/stitching.html)
 ## 
 ## ## Quick Start
 ## If you have a GitHub account, you can get started with nimplex very quickly by just clicking the button below to launch a CodeSpaces environment with everything installed (per instructions in [Reproducible Installation](#reproducible-installation) section) and ready to go! From there, you can either use the CLI tool (as explained in [CLI](#cli) section) or import the library in Python (as explained in [Usage in Python](#usage-in-python) section) and start using it right away. Of course, it also comes with a full Nim compiler and VSCode IDE extensions for Nim, so you can effortlessly modify/extend the source code and re-compile it if you wish.

--- a/nimplex.nim
+++ b/nimplex.nim
@@ -237,9 +237,11 @@ proc simplex_graph_fractional*(dim: int, ndiv: int): (Tensor[float], seq[seq[int
 
 proc attainable2elemental*(simplexPoints: Tensor[SomeNumber],
                            components: seq[seq[SomeNumber]]): Tensor[float] =
-    ## Accepts a `simplexPoints` Arraymancer `Tensor[float]` of shape corresponding to a simplex grid (e.g., from `simplex_grid_fractional`_) or random samples (e.g., from `simplex_sampling_mc`_) and a `components` list of lists of floats, which represents a list of
-    ## compositions in the **elemental** space serving as base components of the **attainable** space given in `simplexPoints`. The `components` can be a row-consistnet mixed list list of integer and fractional compositions, to allow for both types of inputs. 
-    ## It then projects each point from the attainable space to the elemental space using matrix multiplication.
+    ## Projects each point from the attainable space to the elemental space using matrix multiplication. Accepts a `simplexPoints` Arraymancer `Tensor[float]` or `Tensor[int]` of shape corresponding to a simplex grid 
+    ## (e.g., from `simplex_grid_fractional`_) or random samples (e.g., from `simplex_sampling_mc`_) and a `components` list of lists of `float`s or `int`s, which represents a list of compositions in the **elemental** 
+    ## space serving as base components of the **attainable** space given in `simplexPoints`. The `components` can be a row-consistnet mixed list list of integer and fractional compositions, and will be normalized 
+    ## per-row to allow for both types of inputs. Please note that it will *not* automatically normalize the `simplexPoints` rows, so if you give it integer compositions, you will get float values summing to `ndiv`
+    ## rather than `1`.
     runnableExamples:
         const components = @[
             @[0.94, 0.05, 0.01], # Fe95 C5 Mo1

--- a/nimplex.nim
+++ b/nimplex.nim
@@ -29,8 +29,9 @@ when appType == "lib" and not defined(nimdoc):
 when defined(nimdoc):
     # All of (comprehensive) introduction to the documentation lives in this included Nim file, while API is generated from docstrings in the code. It was moved there for cleaner code.
     include docs/docs
-    # The plotting utils are not part of the core library, but are imported during documentation generation to index them as part of the library.
+    # The plotting and stitching utils are not part of the core library, but are imported during documentation generation to index them as part of the library.
     import utils/plotting
+    import utils/stitching
     # Check if `docs/changelog.nim` file is present in the project directory and include it in the documentation if it is.
     import std/os
     when existsFile("docs/changelog.nim"):

--- a/nimplex.nim
+++ b/nimplex.nim
@@ -235,8 +235,8 @@ proc simplex_graph_fractional*(dim: int, ndiv: int): (Tensor[float], seq[seq[int
 
 # CORE UTILS
 
-proc attainable2elemental*(simplexPoints: Tensor[float],
-                           components: seq[seq[float]]): Tensor[float] =
+proc attainable2elemental*(simplexPoints: Tensor[SomeNumber],
+                           components: seq[seq[SomeNumber]]): Tensor[float] =
     ## Accepts a `simplexPoints` Arraymancer `Tensor[float]` of shape corresponding to a simplex grid (e.g., from `simplex_grid_fractional`_) or random samples (e.g., from `simplex_sampling_mc`_) and a `components` list of lists of floats, which represents a list of
     ## compositions in the **elemental** space serving as base components of the **attainable** space given in `simplexPoints`. The `components` can be a row-consistnet mixed list list of integer and fractional compositions, to allow for both types of inputs. 
     ## It then projects each point from the attainable space to the elemental space using matrix multiplication.
@@ -250,11 +250,12 @@ proc attainable2elemental*(simplexPoints: Tensor[float],
         let elementalGrid = grid.attainable2elemental(components)
         echo elementalGrid
     # Tensor of components which can be "integer" ([2,2,1]) or "fractional" ([0.4,0.4,0.2]) compositions
-    var cmpTensor: Tensor[float] = components.toTensor()
+    var cmpTensor: Tensor[float] = components.mapIt(it.mapIt(it.float)).toTensor()
     # Normalize components to sum to 1
     cmpTensor = cmpTensor /. cmpTensor.sum(axis=1)
     # Matrix multiplication to get the final grid
-    result = simplexPoints * cmpTensor
+    let simplexPointsFloat = simplexPoints.asType(float)
+    result = simplexPointsFloat * cmpTensor
 
 func pure_component_indexes*(dim: int, ndiv: int): seq[int] =
     ## This helper function returns a `seq[int]` of indexes of pure components in a simplex grid of `dim` dimensions and `ndiv` divisions per dimension (e.g., from `simplex_grid`_).

--- a/tests/stitching.nim
+++ b/tests/stitching.nim
@@ -1,0 +1,59 @@
+import std/tables
+import std/unittest
+import std/times
+import std/strformat
+import arraymancer/Tensor
+
+import ../nimplex
+import ../utils/stitching
+
+echo "***** Stitching (Graph Complex Construction) Tests *****"
+
+suite "Set up two 3C simplex grids that happen to share a common 2C subspace and verify correct stitching":
+    let t0 = cpuTime()
+    # Set up A B C in A B C D
+    let grid1 = nimplex.simplex_grid_fractional(3, 5).attainable2elemental(@[
+            @[1.0,0.0,0.0,0.0],
+            @[0.0,1.0,0.0,0.0],
+            @[0.0,0.0,1.0,0.0]]
+            )
+
+    # Set up D C A in A B C D
+    let grid2 = nimplex.simplex_grid_fractional(3, 5).attainable2elemental(@[
+            @[0.0,0.0,0.0,1.0],
+            @[0.0,0.0,1.0,0.0],
+            @[1.0,0.0,0.0,0.0]]
+            )
+
+    test "Points generated and are in different spaces":
+        check grid1 != grid2
+
+    let stitch1Table = findStitchingPoints(3, 5, components = @["A", "B", "C"])
+    let stitch2Table = findStitchingPoints(3, 5, components = @["D", "C", "A"])
+
+    test "Stitching tables generated and of correct size (6 ternaries, 6 binaries, 3 unaries = 15)":
+        check stitch1Table.len == 15
+        check stitch2Table.len == 15
+
+    let stitch1 = stitch1Table["C-A"]
+    let stitch2 = stitch2Table["C-A"]
+
+    test "Binary stitching points were extracted from table and are of correct size (ndiv+1 = 6)":
+        check stitch1.len == 6
+        check stitch2.len == 6
+
+    test "Binary stitching points are differently indexed (because they are in different spaces)":
+        check stitch1 != stitch2
+
+    test "Stitching points match expected reference values":
+        check stitch1 == @[0, 6, 11, 15, 18, 20]
+        check stitch2 == @[5, 4, 3, 2, 1, 0]
+
+    for i in 0..<6:
+        let p1 = grid1[stitch1[i], _].squeeze().toSeq1D()
+        let p2 = grid2[stitch2[i], _].squeeze().toSeq1D()
+        test fmt"Stitching point {i} ({p1}) in grid1 matches stitching point {i} in grid2 ({p2})":
+            check p1 == p2
+
+    echo fmt"Finished test in {cpuTime()-t0} seconds."
+    

--- a/utils/plotting.nim
+++ b/utils/plotting.nim
@@ -2,7 +2,7 @@ import arraymancer/Tensor
 
 ## This submodule contains utility functions related to plotting of the compositional data.
 ## 
-## **Navigation:** [nimplex](../nimplex.html) (core library) | [docs/changelog](../docs/changelog.html) | [utils/plotting](plotting.html)
+## **Navigation:** [nimplex](../nimplex.html) (core library) | [docs/changelog](../docs/changelog.html) | [utils/plotting](plotting.html) | [utils/stitching](stitching.html)
 
 proc simplex2cartesian*(simplexPoints: Tensor[float]): Tensor[float] =
     ## Converts Arraymancer `Tensor[float]` of `simplexPoints` with fractional coordinates (e.g., from grid or random sampling) to points in a cartesian space (within unit n-sphere)

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -15,8 +15,16 @@ import ../nimplex
 ## 
 
 func generateAlphabetSequence(length: int): seq[string] =
+    ## Generates a sequence of strings of length `length` containing all UPPER and lower case letters of the alphabet. 
+    ## The primary purpose of this function is to generate unique names for system (A-B-C-D) and its ordered subsystems
+    ## (e.g., A-B, B-A) if no custom names are provided by the user.
     assert length <= 52, "The number of characters requested to name system components exceeds the number of available symbols (52) - uppercase and lowercase letters)."
     const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     for i in 0..<length:
         result.add($alphabet[i])
 
+func nonZeroComps(p: Tensor[int]): seq[int] =
+    ## Finds the indices of non-zero components in the input tensor `p` to determine which (unordered) system/subsystem it belongs to.
+    for i in 0..<p.shape[0]:
+        if p[i] != 0:
+            result.add(i)

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -88,3 +88,11 @@ func compareNodes(
             return 1
     return 0
 
+
+func sortNodes(
+        nodes: var seq[int],
+        coordinateTensor: Tensor[int], 
+        priorityList: seq[int]
+    ): void =
+    ## Sorts a `var` `seq` of node numbers `nodes` using the `compareNodes` function.
+    nodes.sort((x, y) => compareNodes(x, y, coordinateTensor, priorityList))

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -39,3 +39,22 @@ func space2name(space: seq[int], components: seq[string]): string =
         result &= components[i]
         if i != space[space.len-1]:
             result &= "-"
+
+func findSubspace[T](
+        lst: seq[T],
+        maxDim: int = 3
+    ): seq[seq[T]] =
+    ## Finds all possible subspaces of the input list `lst` up to the dimension `maxDim`. The list can be of any type and macro
+    ## will handle it returning a list of lists of the same type. The default `maxDim` is set to 3 because for larger spaces, especially
+    ## high dimensional ones, the number of subspaces grows rapidly (e.g. 1,956 for d=6) and computer memory can be exhausted quicker than
+    ## anticipated when working on it in more intense steps; user can set it to any value they want though.
+    let n = lst.len
+    var sublist = newSeq[T]()
+    
+    for i in 1 ..< (1 shl n):
+        sublist = @[]
+        for j in 0 ..< n:
+            if (i and (1 shl j)) != 0:
+                sublist.add(lst[j])
+        if sublist.len <= maxDim:
+            result.add(sublist)

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -13,7 +13,7 @@ import ../nimplex
 ## on per-subgraph basis, which should be extremely useful for (a) combining the power of many specialized models and (b)
 ## creating stacked spaces for multi-step problems broken down into individual steps.
 ## 
-## **Navigation:** [nimplex](../nimplex.html) (core library) | [docs/changelog](../docs/changelog.html) | [utils/plotting](plotting.html)
+## **Navigation:** [nimplex](../nimplex.html) (core library) | [docs/changelog](../docs/changelog.html) | [utils/plotting](plotting.html) | [utils/stitching](stitching.html)
 ## 
 
 

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -13,3 +13,10 @@ import ../nimplex
 ## 
 ## **Navigation:** [nimplex](../nimplex.html) (core library) | [docs/changelog](../docs/changelog.html) | [utils/plotting](plotting.html)
 ## 
+
+func generateAlphabetSequence(length: int): seq[string] =
+    assert length <= 52, "The number of characters requested to name system components exceeds the number of available symbols (52) - uppercase and lowercase letters)."
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    for i in 0..<length:
+        result.add($alphabet[i])
+

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -58,3 +58,11 @@ func findSubspace[T](
                 sublist.add(lst[j])
         if sublist.len <= maxDim:
             result.add(sublist)
+
+
+func isSubspace(subSpace: seq[int], space: seq[int]): bool =
+    ## Small helper function to check if the input `subSpace` is a subspace of the `space`.
+    for i in subspace:
+        if i notin space:
+            return false
+    return true

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -17,25 +17,25 @@ import ../nimplex
 
 func generateAlphabetSequence(length: int): seq[string] =
     ## Generates a sequence of strings of length `length` containing all UPPER and lower case letters of the alphabet. 
-    ## The primary purpose of this function is to generate unique names for system (A-B-C-D) and its ordered subsystems
+    ## The primary purpose of this function is to generate unique names for space (A-B-C-D) and its ordered subspaces
     ## (e.g., A-B, B-A) if no custom names are provided by the user.
-    assert length <= 52, "The number of characters requested to name system components exceeds the number of available symbols (52) - uppercase and lowercase letters)."
+    assert length <= 52, "The number of characters requested to name space components exceeds the number of available symbols (52) - uppercase and lowercase letters)."
     const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     for i in 0..<length:
         result.add($alphabet[i])
 
 
 func nonZeroComps(p: Tensor[int]): seq[int] =
-    ## Finds the indices of non-zero components in the input tensor `p` to determine which (unordered) system/subsystem it belongs to.
+    ## Finds the indices of non-zero components in the input tensor `p` to determine which (unordered) space/subspace it belongs to.
     for i in 0..<p.shape[0]:
         if p[i] != 0:
             result.add(i)
 
 
-func sys2name(sys: seq[int], components: seq[string]): string =
-    ## Converts the system/subsystem represented by the indices in `sys` to a string representation using the names of the `components`.
+func space2name(space: seq[int], components: seq[string]): string =
+    ## Converts the space/subspace represented by the indices in `space` to a string representation using the names of the `components`.
     ## It can be used in conjunction with `generateAlphabetSequence` too.
-    for i in sys:
+    for i in space:
         result &= components[i]
-        if i != sys[sys.len-1]:
+        if i != space[space.len-1]:
             result &= "-"

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -1,0 +1,15 @@
+import std/tables
+import std/math
+import std/algorithm
+import std/sugar
+import arraymancer/Tensor
+import ../nimplex
+
+## This submodule contains utility functions related to stitching of the compositional graphs to form graph complexes, so that
+## much more complex graphs can be built from simpler ones while retaining homogeneous structure of the space. Furthermore,
+## one can keep track of provenance of the subgraphs and use this information to deploy computational (e.g., ML) models
+## on per-subgraph basis, which should be extremely useful for (a) combining the power of many specialized models and (b)
+## creating stacked spaces for multi-step problems broken down into individual steps.
+## 
+## **Navigation:** [nimplex](../nimplex.html) (core library) | [docs/changelog](../docs/changelog.html) | [utils/plotting](plotting.html)
+## 

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -14,6 +14,7 @@ import ../nimplex
 ## **Navigation:** [nimplex](../nimplex.html) (core library) | [docs/changelog](../docs/changelog.html) | [utils/plotting](plotting.html)
 ## 
 
+
 func generateAlphabetSequence(length: int): seq[string] =
     ## Generates a sequence of strings of length `length` containing all UPPER and lower case letters of the alphabet. 
     ## The primary purpose of this function is to generate unique names for system (A-B-C-D) and its ordered subsystems
@@ -23,8 +24,18 @@ func generateAlphabetSequence(length: int): seq[string] =
     for i in 0..<length:
         result.add($alphabet[i])
 
+
 func nonZeroComps(p: Tensor[int]): seq[int] =
     ## Finds the indices of non-zero components in the input tensor `p` to determine which (unordered) system/subsystem it belongs to.
     for i in 0..<p.shape[0]:
         if p[i] != 0:
             result.add(i)
+
+
+func sys2name(sys: seq[int], components: seq[string]): string =
+    ## Converts the system/subsystem represented by the indices in `sys` to a string representation using the names of the `components`.
+    ## It can be used in conjunction with `generateAlphabetSequence` too.
+    for i in sys:
+        result &= components[i]
+        if i != sys[sys.len-1]:
+            result &= "-"

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -66,3 +66,25 @@ func isSubspace(subSpace: seq[int], space: seq[int]): bool =
         if i notin space:
             return false
     return true
+
+
+func compareNodes(
+        a: int, 
+        b: int, 
+        nodeCoordinateTensor: Tensor[int], 
+        priorityList: seq[int]
+    ): int =
+    ## Comparator function to evaluate the order of two node numbers `a` and `b` based on their coordinates in the compositional space given in 
+    ## `nodeCoordinateTensor` of `int`s (e.g. `simplex_grid` output or the first element in the `simplex_graph` output tuple), ranked by
+    ## the `priorityList` establishing order of dimensions in the ordered subspace one may be interested in. 
+    let 
+        p1 = nodeCoordinateTensor[a, _].squeeze()
+        p2 = nodeCoordinateTensor[b, _].squeeze()
+
+    for p in priorityList:
+        if p1[p] > p2[p]:
+            return -1
+        if p1[p] < p2[p]:
+            return 1
+    return 0
+

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -2,6 +2,7 @@ import std/tables
 import std/math
 import std/algorithm
 import std/sugar
+import std/strformat
 import arraymancer/Tensor
 import ../nimplex
 
@@ -170,3 +171,14 @@ proc findStitchingPoints*(
         for p in permutations:
             sortedSys.sortNodes(result[0], p)
             result[1][space2name(p, components)] = sortedSys
+
+if isMainModule:
+    let stitch = findStitchingPoints(5, 5, 3)
+    for space in stitch[1].keys:
+        echo fmt"{space:<7} -> {stitch[1][space]}"
+    
+    echo "\n\n\n"
+
+    let stitch2 = findStitchingPoints(3, 4, 3, @["Ti", "V", "Cr"])
+    for space in stitch2[1].keys:
+        echo fmt"{space:<7} -> {stitch2[1][space]}"

--- a/utils/stitching.nim
+++ b/utils/stitching.nim
@@ -96,3 +96,19 @@ func sortNodes(
     ): void =
     ## Sorts a `var` `seq` of node numbers `nodes` using the `compareNodes` function.
     nodes.sort((x, y) => compareNodes(x, y, coordinateTensor, priorityList))
+
+
+func permutations[T](s: seq[T]): seq[seq[T]] =
+    ## Generates all possible permutations of the input sequence `s` using a recursive algorithm. Can accept any type of sequence thanks
+    ## to Nim's powerful type system and reurns a sequence of sequences of the same type.
+    if s.len == 0:
+        return @[]
+    if s.len == 1:
+        return @[s]
+    
+    var xs: seq[T]
+    for i in 0..<s.len:
+        let x = s[i]
+        xs = s[0..<i] & s[i+1..^1]
+        for p in permutations(xs):
+            result.add(@[x] & p)


### PR DESCRIPTION
This PR adds the ability to generate N-dimensional stitching points between any higher-dimensional graphs. 

- It's quite a big deal because now you will be able to set up connectivities between any high-dimensional search spaces to, e.g., connect design space A-G-D-H-I-B with H-I-E-F-A-C-D through shared A-D-H-I tetrahedron of compositions.

- This brings exciting modeling opportunities, like the ability to *efortlessly* bridge full design spaces of advanced alloys like stainless steels, nickel-based superalloys, and titanium alloys by stitching only the shared components, while using models (thermodynamic or ML) only within intended elemental spaces. 

- Some further critical advantages are also enabled and will be shared at a later time through publications.

- See `tests/stitching.nim` for some examples.